### PR TITLE
Changing the uv offset to match the TRANSFORM_TEX macro

### DIFF
--- a/TriplanarDerivativeCotangents.shader
+++ b/TriplanarDerivativeCotangents.shader
@@ -92,9 +92,9 @@ Shader "Triplanar/Derivative Cotangents"
 
                 // calculate triplanar uvs
                 // applying texture scale and offset values ala TRANSFORM_TEX macro
-                float2 uvX = i.worldPos.zy * _MainTex_ST.xy + _MainTex_ST.zy;
-                float2 uvY = i.worldPos.xz * _MainTex_ST.xy + _MainTex_ST.zy;
-                float2 uvZ = i.worldPos.xy * _MainTex_ST.xy + _MainTex_ST.zy;
+                float2 uvX = i.worldPos.zy * _MainTex_ST.xy + _MainTex_ST.zw;
+                float2 uvY = i.worldPos.xz * _MainTex_ST.xy + _MainTex_ST.zw;
+                float2 uvZ = i.worldPos.xy * _MainTex_ST.xy + _MainTex_ST.zw;
 
                 // offset UVs to prevent obvious mirroring
             #if defined(TRIPLANAR_UV_OFFSET)

--- a/TriplanarGPUGems3.shader
+++ b/TriplanarGPUGems3.shader
@@ -70,9 +70,9 @@ Shader "Triplanar/GPU Gems 3"
 
                 // calculate triplanar uvs
                 // applying texture scale and offset values ala TRANSFORM_TEX macro
-                float2 uvX = i.worldPos.zy * _MainTex_ST.xy + _MainTex_ST.zy;
-                float2 uvY = i.worldPos.xz * _MainTex_ST.xy + _MainTex_ST.zy;
-                float2 uvZ = i.worldPos.xy * _MainTex_ST.xy + _MainTex_ST.zy;
+                float2 uvX = i.worldPos.zy * _MainTex_ST.xy + _MainTex_ST.zw;
+                float2 uvY = i.worldPos.xz * _MainTex_ST.xy + _MainTex_ST.zw;
+                float2 uvZ = i.worldPos.xy * _MainTex_ST.xy + _MainTex_ST.zw;
 
                 // offset UVs to prevent obvious mirroring
             #if defined(TRIPLANAR_UV_OFFSET)

--- a/TriplanarRNM.shader
+++ b/TriplanarRNM.shader
@@ -81,9 +81,9 @@ Shader "Triplanar/Reoriented Normal Mapping"
 
                 // calculate triplanar uvs
                 // applying texture scale and offset values ala TRANSFORM_TEX macro
-                float2 uvX = i.worldPos.zy * _MainTex_ST.xy + _MainTex_ST.zy;
-                float2 uvY = i.worldPos.xz * _MainTex_ST.xy + _MainTex_ST.zy;
-                float2 uvZ = i.worldPos.xy * _MainTex_ST.xy + _MainTex_ST.zy;
+                float2 uvX = i.worldPos.zy * _MainTex_ST.xy + _MainTex_ST.zw;
+                float2 uvY = i.worldPos.xz * _MainTex_ST.xy + _MainTex_ST.zw;
+                float2 uvZ = i.worldPos.xy * _MainTex_ST.xy + _MainTex_ST.zw;
 
                 // offset UVs to prevent obvious mirroring
             #if defined(TRIPLANAR_UV_OFFSET)

--- a/TriplanarReconstructedBitangents.shader
+++ b/TriplanarReconstructedBitangents.shader
@@ -73,9 +73,9 @@ Shader "Triplanar/Reconstructed Bitangents"
 
                 // calculate triplanar uvs
                 // applying texture scale and offset values ala TRANSFORM_TEX macro
-                float2 uvX = i.worldPos.zy * _MainTex_ST.xy + _MainTex_ST.zy;
-                float2 uvY = i.worldPos.xz * _MainTex_ST.xy + _MainTex_ST.zy;
-                float2 uvZ = i.worldPos.xy * _MainTex_ST.xy + _MainTex_ST.zy;
+                float2 uvX = i.worldPos.zy * _MainTex_ST.xy + _MainTex_ST.zw;
+                float2 uvY = i.worldPos.xz * _MainTex_ST.xy + _MainTex_ST.zw;
+                float2 uvZ = i.worldPos.xy * _MainTex_ST.xy + _MainTex_ST.zw;
 
                 // offset UVs to prevent obvious mirroring
             #if defined(TRIPLANAR_UV_OFFSET)

--- a/TriplanarReconstructedTangents.shader
+++ b/TriplanarReconstructedTangents.shader
@@ -71,9 +71,9 @@ Shader "Triplanar/Reconstructed Tangents"
 
                 // calculate triplanar uvs
                 // applying texture scale and offset values ala TRANSFORM_TEX macro
-                float2 uvX = i.worldPos.zy * _MainTex_ST.xy + _MainTex_ST.zy;
-                float2 uvY = i.worldPos.xz * _MainTex_ST.xy + _MainTex_ST.zy;
-                float2 uvZ = i.worldPos.xy * _MainTex_ST.xy + _MainTex_ST.zy;
+                float2 uvX = i.worldPos.zy * _MainTex_ST.xy + _MainTex_ST.zw;
+                float2 uvY = i.worldPos.xz * _MainTex_ST.xy + _MainTex_ST.zw;
+                float2 uvZ = i.worldPos.xy * _MainTex_ST.xy + _MainTex_ST.zw;
 
                 // offset UVs to prevent obvious mirroring
             #if defined(TRIPLANAR_UV_OFFSET)

--- a/TriplanarSurfaceShader.shader
+++ b/TriplanarSurfaceShader.shader
@@ -79,9 +79,9 @@ Shader "Triplanar/Surface Shader (RNM)" {
 
             // calculate triplanar uvs
             // applying texture scale and offset values ala TRANSFORM_TEX macro
-            float2 uvX = IN.worldPos.zy * _MainTex_ST.xy + _MainTex_ST.zy;
-            float2 uvY = IN.worldPos.xz * _MainTex_ST.xy + _MainTex_ST.zy;
-            float2 uvZ = IN.worldPos.xy * _MainTex_ST.xy + _MainTex_ST.zy;
+            float2 uvX = IN.worldPos.zy * _MainTex_ST.xy + _MainTex_ST.zw;
+            float2 uvY = IN.worldPos.xz * _MainTex_ST.xy + _MainTex_ST.zw;
+            float2 uvZ = IN.worldPos.xy * _MainTex_ST.xy + _MainTex_ST.zw;
 
             // offset UVs to prevent obvious mirroring
         #if defined(TRIPLANAR_UV_OFFSET)

--- a/TriplanarWhiteout.shader
+++ b/TriplanarWhiteout.shader
@@ -70,9 +70,9 @@ Shader "Triplanar/Whiteout Blend"
 
                 // calculate triplanar uvs
                 // applying texture scale and offset values ala TRANSFORM_TEX macro
-                float2 uvX = i.worldPos.zy * _MainTex_ST.xy + _MainTex_ST.zy;
-                float2 uvY = i.worldPos.xz * _MainTex_ST.xy + _MainTex_ST.zy;
-                float2 uvZ = i.worldPos.xy * _MainTex_ST.xy + _MainTex_ST.zy;
+                float2 uvX = i.worldPos.zy * _MainTex_ST.xy + _MainTex_ST.zw;
+                float2 uvY = i.worldPos.xz * _MainTex_ST.xy + _MainTex_ST.zw;
+                float2 uvZ = i.worldPos.xy * _MainTex_ST.xy + _MainTex_ST.zw;
 
                 // offset UVs to prevent obvious mirroring
             #if defined(TRIPLANAR_UV_OFFSET)


### PR DESCRIPTION
Changing the uv offset to use zw rather than zy to match the TRANSFORM_TEX macro.